### PR TITLE
Fixed option location for mv in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,10 @@ help:
 rota:
 	python3 scripts/generateRota.py
 	cp rota-2018.ics rota.ics
-	mv rota*ics content/files/ -v
-	mv rota*txt content/pages/ -v
-	
-	
+	mv -v rota*ics content/files/
+	mv -v rota*txt content/pages/
+
+
 taglist:
 	grep -o -h '^:tags:.*' content/*rst  | sed 's/:tags: //' | tr ',' '\n' | sed 's/^[[:space:]]*//' | sort | uniq | sed '/^[[:space:]]*$$/ d' | tr '\n' ',' | sed 's/,/, /g' | sed 's/,[[:space:]]*$$//'
 

--- a/content/files/rota-2018.ics
+++ b/content/files/rota-2018.ics
@@ -119,12 +119,14 @@ UID:2018-04-17T00:00:00-00:01
 LOCATION:C258\, College Lane\, University of Hertfordshire\, Hatfield\, UK
 END:VEVENT
 BEGIN:VEVENT
-SUMMARY:Mohammad Tayarani - A Dynamic Evolutionary Car Engine Calibration 
- Algorithm for Engines in Dynamic Environments
-DTSTART;TZID=Europe/London:20180418T110000
-DTEND;TZID=Europe/London:20180418T120000
-UID:2018-04-18T00:00:00-00:01
-LOCATION:C258\, College Lane\, University of Hertfordshire\, Hatfield\, UK
+SUMMARY:Majid Zamani - A Highly Accurate Spike Sorting Processor With Reco
+ nfigurable Embedded Frames for Unsupervised and Adaptive Analysis of Neura
+ l Signals
+DTSTART;TZID=Europe/London:20180419T100000
+DTEND;TZID=Europe/London:20180419T110000
+UID:2018-04-19T00:00:00-00:01
+LOCATION:1H276\, College Lane\, University of Hertfordshire\, Hatfield\, U
+ K
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Anna Dumitriu and Alex May - ArchaeaBot: A Post Singularity\, Post

--- a/content/files/rota.ics
+++ b/content/files/rota.ics
@@ -119,12 +119,14 @@ UID:2018-04-17T00:00:00-00:01
 LOCATION:C258\, College Lane\, University of Hertfordshire\, Hatfield\, UK
 END:VEVENT
 BEGIN:VEVENT
-SUMMARY:Mohammad Tayarani - A Dynamic Evolutionary Car Engine Calibration 
- Algorithm for Engines in Dynamic Environments
-DTSTART;TZID=Europe/London:20180418T110000
-DTEND;TZID=Europe/London:20180418T120000
-UID:2018-04-18T00:00:00-00:01
-LOCATION:C258\, College Lane\, University of Hertfordshire\, Hatfield\, UK
+SUMMARY:Majid Zamani - A Highly Accurate Spike Sorting Processor With Reco
+ nfigurable Embedded Frames for Unsupervised and Adaptive Analysis of Neura
+ l Signals
+DTSTART;TZID=Europe/London:20180419T100000
+DTEND;TZID=Europe/London:20180419T110000
+UID:2018-04-19T00:00:00-00:01
+LOCATION:1H276\, College Lane\, University of Hertfordshire\, Hatfield\, U
+ K
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Anna Dumitriu and Alex May - ArchaeaBot: A Post Singularity\, Post

--- a/scripts/rota-data-2018.csv
+++ b/scripts/rota-data-2018.csv
@@ -15,7 +15,7 @@ Yi Sun,"Singular Spectrum Analysis - A very short introduction​","20180321-sin
 ---,,,0,0,0,0,1
 Anna Dumitriu and Alex May,"ArchaeaBot: A Post Singularity, Post Climate Change Lifeform","20180413-archaeabot-a-post-singularity-post-climate-change-lifeform.rst",2018-04-20,1600,1700,0,1
 "Dr. Faramarz Faghihi","Brain-inspired Spiking Neural Networks for Neuromorphic Deep Learning and Neuromorphic Reinforcement Learning Methods", "#",2018-04-17,1530,1630,"C258, College Lane, University of Hertfordshire, Hatfield, UK",0
-"Mohammad Tayarani","A Dynamic Evolutionary Car Engine Calibration Algorithm for Engines in Dynamic Environments", "#",2018-04-18,1100,1200,"C258, College Lane, University of Hertfordshire, Hatfield, UK",0
+"Majid Zamani","A Highly Accurate Spike Sorting Processor With Reconfigurable Embedded Frames for Unsupervised and Adaptive Analysis of Neural Signals", "#",2018-04-19,1000,1100,"1H276, College Lane, University of Hertfordshire, Hatfield, UK",0
 Jean Petrić,,,0,0,0,0,1
 Maria Psarrou,,,2018-05-04,1600,1700,0,1
 Anuradha Sulane,,,0,0,0,0,1


### PR DESCRIPTION
`mv <file> <location> -v` doesn't work on macOS, it needs to be `mv -v <file> <location>`.

fixed this for the `rota` target. 