### PR TITLE
Replace "{filename}/images" to "{static}/images" to adjust latest

### DIFF
--- a/content/pages/01-index.rst
+++ b/content/pages/01-index.rst
@@ -12,19 +12,19 @@ The `Biocomputation Research Group <#>`__ forms part of the `Centre for Computer
 
     <center>
 
-.. image:: {filename}/images/dna-sequence-1570578-639x427.jpg
+.. image:: {static}/images/dna-sequence-1570578-639x427.jpg
     :height: 200px
-    :target: {filename}/images/dna-sequence-1570578-639x427.jpg
+    :target: {static}/images/dna-sequence-1570578-639x427.jpg
     :alt: DNA sequence from Freeimages.com under the FreeImages.com content license.
 
-.. image:: {filename}/images/BoB.png
+.. image:: {static}/images/BoB.png
     :height: 200px
-    :target: {filename}/images/BoB.png
+    :target: {static}/images/BoB.png
     :alt: BoB
 
-.. image:: {filename}/images/Purkinje_bw.png
+.. image:: {static}/images/Purkinje_bw.png
     :height: 200px
-    :target: {filename}/images/Purkinje_bw.png
+    :target: {static}/images/Purkinje_bw.png
     :alt: Purkinje cell
 
 .. raw:: html

--- a/content/pages/02-research.rst
+++ b/content/pages/02-research.rst
@@ -6,9 +6,9 @@ Research in the Biocomputation Laboratory involves the application of computatio
 
 Research in `Computational Neuroscience <#>`__ (led by Dr. Steuber, in collaboration with Dr. Davey, Prof Adams and Dr. Schilstra) focuses on the development, simulation and analysis of computational models of neurons and neuronal networks in order to understand information processing in the brain. To constrain and test the models, the Computational Neuroscience Team collaborates closely with world-leading neuroscientists in the UK, France, Japan, Israel, the Netherlands and the USA. The team applies a multi-scale systems biology approach, using models at scales ranging from biochemical processes to neuronal networks and behaviour, and interacting continuously with anatomists, neurophysiologists and biochemists that investigate neuronal systems at multiple levels of description.
 
-.. image:: {filename}/images/2purk_calcium.jpg
+.. image:: {static}/images/2purk_calcium.jpg
     :width: 400px
-    :target: {filename}/images/2purk_calcium.jpg
+    :target: {static}/images/2purk_calcium.jpg
     :align: center
     :alt: Purkinje cell
 
@@ -18,9 +18,9 @@ Research in `Brain-inspired Data Science and Neuromorphic Computing <http://biom
 
 Research in `Computational Systems Biology <#>`__ is led by Dr. Schilstra (in collaboration with Dr. Steuber and Prof Nehaniv) and involves the development of visualization and mixed-mode stochastic simulation tools for biochemical reaction networks. Current and potential applications of these tools include basic medical research such as studying the effect of anti-cancer drugs, and the visualization of biological processes for education purposes (in collaboration with the School of Creative Arts at UH).
 
-.. image:: {filename}/images/MoreBoB.png
+.. image:: {static}/images/MoreBoB.png
     :width: 400px
-    :target: {filename}/images/MoreBoB.png
+    :target: {static}/images/MoreBoB.png
     :align: center
     :alt: BoB2
 

--- a/content/pages/06-collaborators.rst
+++ b/content/pages/06-collaborators.rst
@@ -90,9 +90,9 @@ Software Developed in Collaboration with Other Institutions
 - neuroConstruct_ |br|
   Software for the construction and visualisation of biologically detailed neuronal networks in 3D.
 
-.. image:: {filename}/images/neuroConstruct_Large.jpg
+.. image:: {static}/images/neuroConstruct_Large.jpg
     :align: center
-    :target: {filename}/images/neuroConstruct_Large.jpg
+    :target: {static}/images/neuroConstruct_Large.jpg
     :alt: simple cerebellar network model in neuroConstruct (P. Gleeson)
 
 .. _neuroConstruct: http://www.neuroconstruct.org/

--- a/content/pages/07-SOP-admins.rst
+++ b/content/pages/07-SOP-admins.rst
@@ -228,8 +228,8 @@ Non admins can open pull requests as documented in the nonadmin SOP document. Ad
 
 Pull requests that have been correctly created do not require anything other than a button click. They will specify that the pull request was made correctly and that the merge can be made without issues as shown in the figure below:
 
-.. image:: {filename}/images/github-merge-pull-request.png
-    :target: {filename}/images/github-merge-pull-request.png
+.. image:: {static}/images/github-merge-pull-request.png
+    :target: {static}/images/github-merge-pull-request.png
     :alt: Open a pull request.
 
 However, an admin should generally check that the changes made in the pull request are all correct. For small changes, you can just click on the "**Files changed**" tab and verify the changes. If they're OK, you can merge the pull request right away. For larger changes, you will have to checkout the person's branch, test the changes and then merge the request. The instructions to do this can be seen by clicking the "command line instructions" link in the merge ticket.

--- a/content/pages/08-SOP-nonadmins.rst
+++ b/content/pages/08-SOP-nonadmins.rst
@@ -62,14 +62,14 @@ Fork the sources and make the changes
 
 Since non admins do not have write access to the repository, they must fork the repository on Github before proceeding. One must be signed in to Github to fork a repository. Once signed in, one can navigate to the repository they intend to fork and click on the fork button in the top right corner as shown in the image below:
 
-.. image:: {filename}/images/github-fork.png
-    :target: {filename}/images/github-fork.png
+.. image:: {static}/images/github-fork.png
+    :target: {static}/images/github-fork.png
     :alt: fork a repository
 
 Once the fork is complete, one will have a copy of the repository under one's username, as shown in the image below:
 
-.. image:: {filename}/images/github-fork-complete.png
-    :target: {filename}/images/github-fork-complete.png
+.. image:: {static}/images/github-fork-complete.png
+    :target: {static}/images/github-fork-complete.png
     :alt: forked a repository
 
 
@@ -148,8 +148,8 @@ Open a pull request on Github.
 
 Once the changes have been pushed to one's fork, navigate to the main repository. Github will detect that the fork has extra commits and ask if pull request needs to be opened, as shown in the image below:
 
-.. image:: {filename}/images/github-detect-push.png
-    :target: {filename}/images/github-detect-push.png
+.. image:: {static}/images/github-detect-push.png
+    :target: {static}/images/github-detect-push.png
     :alt: Github asks to open a pull request.
 
 |
@@ -158,8 +158,8 @@ Once the changes have been pushed to one's fork, navigate to the main repository
 When the button is clicked, it'll navigate to the next page where details on
 the pull request can be provided:
 
-.. image:: {filename}/images/github-open-pull-request.png
-    :target: {filename}/images/github-open-pull-request.png
+.. image:: {static}/images/github-open-pull-request.png
+    :target: {static}/images/github-open-pull-request.png
     :alt: Open a pull request.
 
 Here, as expected, the main repository is the **base fork**, while one's personal fork is the **head fork**. At the bottom of the page, which is not shown in the image above, it will also show what changes have been made. Please ensure that the "Able to merge" message appears here - if it does not, please contact one of the admins - merging would result in a conflict.


### PR DESCRIPTION
Replace "{filename}/images" to "{static}/images" to adjust latest pelican and supress warning messages.

It is just used for links to images, and I confirmed it did not affect anything on the generated pages. After I replaced them and executed ```$ make html```, no html files were modified (confirmed by ```$ git status```). It is just for eliminating warning messages.